### PR TITLE
feat: make details input optional in PinForm

### DIFF
--- a/App.js
+++ b/App.js
@@ -108,12 +108,12 @@ export default class App extends React.Component {
 
   _onChangeType = input => {
     if (!input) return;
-      this.setState({
-        newPin: {
-          ...this.state.newPin,
-          type: input
-        }
-      });
+    this.setState({
+      newPin: {
+        ...this.state.newPin,
+        type: input
+      }
+    });
   };
 
   _handleSubmit = () => {
@@ -122,7 +122,6 @@ export default class App extends React.Component {
 
     const pinObj = {
       title: this.state.newPin.title,
-      details: this.state.newPin.details,
       type: this.state.newPin.type,
       userID: this.state.user_id,
       coordinate: {
@@ -130,6 +129,10 @@ export default class App extends React.Component {
         longitude: this.state.newPin.coordinate.longitude
       }
     };
+    // optional fields here
+    if (this.state.newPin.details && this.state.newPin.details.length > 0) {
+      pinObj.details = this.state.newPin.details;
+    }
     createPin(pinObj);
   };
 

--- a/Components/PinForm.js
+++ b/Components/PinForm.js
@@ -29,12 +29,6 @@ export default class PinForm extends React.Component {
             {"This field is required"}
           </FormValidationMessage>
 
-          <FormLabel>Details</FormLabel>
-          <FormInput value={this.props.screenProps.newPin.details} onChangeText={this.props.screenProps._onChangeDetails} />
-          <FormValidationMessage>
-            {"This field is required"}
-          </FormValidationMessage>
-
           <FormLabel>Type</FormLabel>
           {/* <FormInput value={this.props.screenProps.newPin.type} onChangeText={this.props.screenProps._onChangeType} /> */}
           <Picker
@@ -50,6 +44,9 @@ export default class PinForm extends React.Component {
           {/* <FormValidationMessage>
             {"This field is required"}
           </FormValidationMessage> */}
+
+          <FormLabel>Details</FormLabel>
+          <FormInput value={this.props.screenProps.newPin.details} onChangeText={this.props.screenProps._onChangeDetails} />
 
           <Button
             style={styles.button}


### PR DESCRIPTION
As a user in a time-sensitive situation, I want to be able to create pins without inputting `details` text.
